### PR TITLE
talks: add 'My Talks' section with slides, description

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ $ npm run start
 |home|welcome, introduction, and worklog|
 |about|resume for employers displaying data from [atla5/resume](https://github.com/atla5/resume/)|
 |projects|list of projects with descriptions stored in [projects.json](https://github.com/atla5/resume/blob/master/data/projects.json)|
+|talks|presentations and workshops I've given over the years, fed by [presentations.json](https://github.com/atla5/resume/blob/master/data/presentations.json)|
 
 
 ## design rationale

--- a/index.html
+++ b/index.html
@@ -40,14 +40,12 @@
 
     <section name="javascript-disabled">
       <noscript>
-        <hr>
-        <em>
+        <p>
           This page loads much of its content from another project (
           <a href="https://github.com/atla5/resume/">atla5/resume</a>
           ). If you're not seeing what you think you should, try enabling
           javascript, or trying a more <a href="https://www.epicbrowser.com/">modern browser</a>.
-        </em>
-        <hr>
+        </p>
       </noscript>
     </section>
 
@@ -141,13 +139,13 @@
       <input type="radio" name="main-content" id="projects">
       <label for="projects">My Projects</label>
       <div name="projects-content">
-        <h2>Projects I've Worked On</h2>
         <noscript>
           <p>
             if you have javascript turned off, you're not able to see a 
             <a href="https://github.com/atla5/resume/blob/master/data/projects.json">list of projects</a>.
           </p>
         </noscript>
+        <h2>Projects I've Worked On</h2>
         <section id="projects-detail"><em>loading project list...</em></section>
       </div>
       
@@ -155,13 +153,13 @@
       <input type="radio" name="main-content" id="talks">
       <label for="talks">My Talks</label>
       <div name="talks-content">
-        <h2>Talks I've Given</h2>
         <noscript>
           <p>
             if you have javascript turned off, you're not able to see a 
             <a href="https://github.com/atla5/resume/blob/master/data/presentations.json">list of talks</a>.
           </p>
         </noscript>
+        <h2>Talks I've Given</h2>
         <section id="talks-list"><em>loading talks...</em></section>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -8,7 +8,9 @@
 
     <title>Aidan Sawyer</title>
     <link rel="icon" type="image/x-icon" href="https://avatars3.githubusercontent.com/u/5565284">
-    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/bulib-wc@latest/dist/bundle.min.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/atla5/utils/css/spacing.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/atla5/utils/css/variables.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/gh/atla5/utils/css/tabs.min.css">
     <link rel="stylesheet" type="text/css" href="./src/styles.css">
 
     <script src="https://unpkg.com/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>

--- a/index.html
+++ b/index.html
@@ -117,6 +117,13 @@
       <input type="radio" name="main-content" id="resume">
       <label for="resume">My Resume</label>
       <div name="resume-content">
+        <noscript>
+          <p>
+            if you have javascript turned off, you're not able to see a bunch of information from my resume.
+            you can <a href="https://github.com/atla5/resume/raw/master/build/Resume_Sawyer.pdf" download>download a pdf version</a>
+            or browse through <a href="https://github.com/atla5/resume/">the repository</a>.
+          </p>
+        </noscript>
         <h2>Education</h2>
         <section id="education"><em>loading schools...</em></section>
         
@@ -134,6 +141,13 @@
       <input type="radio" name="main-content" id="projects">
       <label for="projects">My Projects</label>
       <div name="projects-content">
+        <h2>Projects I've Worked On</h2>
+        <noscript>
+          <p>
+            if you have javascript turned off, you're not able to see a 
+            <a href="https://github.com/atla5/resume/blob/master/data/projects.json">list of projects</a>.
+          </p>
+        </noscript>
         <section id="projects-detail"><em>loading project list...</em></section>
       </div>
       
@@ -142,6 +156,12 @@
       <label for="talks">My Talks</label>
       <div name="talks-content">
         <h2>Talks I've Given</h2>
+        <noscript>
+          <p>
+            if you have javascript turned off, you're not able to see a 
+            <a href="https://github.com/atla5/resume/blob/master/data/presentations.json">list of talks</a>.
+          </p>
+        </noscript>
         <section id="talks-list"><em>loading talks...</em></section>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
           to the huge <a href="https://technostacks.com/blog/javascript-frameworks/">framework-of-the-day</a>, 
           some elaborate and complicated <a href="https://github.com/webpack/webpack">build system</a>, 
           a variety of large <a href="https://en.wikipedia.org/wiki/Dependency_hell">extraneous libraries</a>, 
-          and even - it's true - without <em>vanilla</em> javascript or CSS.
+          and even <em>vanilla</em> javascript or CSS.
         </p>
 
         <p>
@@ -133,6 +133,14 @@
       <label for="projects">My Projects</label>
       <div name="projects-content">
         <section id="projects-detail"><em>loading project list...</em></section>
+      </div>
+      
+      <!-- PRESENTATIONS -->
+      <input type="radio" name="main-content" id="talks">
+      <label for="talks">My Talks</label>
+      <div name="talks-content">
+        <h2>Talks I've Given</h2>
+        <section id="talks-list"><em>loading talks...</em></section>
       </div>
 
       <!-- resume download-->

--- a/src/index.js
+++ b/src/index.js
@@ -123,13 +123,12 @@ async function renderSkills(skills_json){
 
 
 /* -- PRESENTATIONS -- */
-let presentations_url = "https://raw.githubusercontent.com/atla5/resume/presentations/data/"+"presentations.json";
+let presentations_url = url_base_data+"presentations.json";
 getDataFromJSONFileAndCallRenderFunction(presentations_url, renderTalks);
 const temp_talk = (talk) => html`
   <li>
     <div style="display: flex; flex-wrap: wrapped;">
-      <iframe class="pal" width="450" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true" 
-        src="https://docs.google.com/presentation/d/e/2PACX-1vTEFVU1iY8Uz0EY1jAzwJaXuUNJwEGLpLTozAWOiPd-t_PBb6P7Z-NabxS5rr1u4yf0CLWmeJg3fDvk/embed"></iframe>
+      <iframe class="pal" width="450" src="${talk.slides_embed}" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
       <div class="pll txtv">
         <h3 class="mbm">${talk.title} [<a target="_blank" href="https://docs.google.com/presentation/d/${talk.slides_id}/edit?usp=sharing">slides</a>]</h3>
         <em class="pbl">${talk.subtitle}</em>

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ async function renderJobs(jobs){
   render(jobsTemplate(jobs.slice(0,3)), document.getElementById("jobs"));
 };
 
+
 /* -- PROJECTS (resume) -- */
 let projects_url = url_base_data+"projects.json";
 getDataFromJSONFileAndCallRenderFunction(projects_url, renderProjects);
@@ -91,7 +92,6 @@ const temp_project_detail = (project) => html`
   }
 
 
-
 /* -- SKILLS -- */
 let skills_url = url_base_data+"additional.json";
 getDataFromJSONFileAndCallRenderFunction(skills_url, renderSkills);
@@ -120,6 +120,50 @@ async function renderSkills(skills_json){
 
   render(temp_languages(novice, functional, intermediate), document.getElementById("skills"));
 }
+
+
+/* -- PRESENTATIONS -- */
+let presentations_url = "https://raw.githubusercontent.com/atla5/resume/presentations/data/"+"presentations.json";
+getDataFromJSONFileAndCallRenderFunction(presentations_url, renderTalks);
+const temp_talk = (talk) => html`
+  <li>
+    <div style="display: flex; flex-wrap: wrapped;">
+      <iframe class="pal" width="450" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true" 
+        src="https://docs.google.com/presentation/d/e/2PACX-1vTEFVU1iY8Uz0EY1jAzwJaXuUNJwEGLpLTozAWOiPd-t_PBb6P7Z-NabxS5rr1u4yf0CLWmeJg3fDvk/embed"></iframe>
+      <div class="pll txtv">
+        <h3 class="mbm">${talk.title} [<a target="_blank" href="https://docs.google.com/presentation/d/${talk.slides_id}/edit?usp=sharing">slides</a>]</h3>
+        <em class="pbl">${talk.subtitle}</em>
+        <p>${talk.description}</p>
+        <div>
+          <strong><a href="${talk.conference_url}">${talk.conference_name}</a></strong> - 
+          <span>${humanize_date(talk.date)}</div>
+        </div>
+      </div>
+    </div>
+  </li><hr />`;
+const temp_talks = (talks) => html`<ul class="no-bullet"><hr />${talks.map((talk) => temp_talk(talk))}</ul>`;
+async function renderTalks(presentations){
+  render(temp_talks(presentations), document.getElementById("talks-list"));
+}
+
+
+/* -- HELPERS -- */
+
+
+/* humanize dates from '2020-03-23' to 'March 3, 2020' */
+const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
+function humanize_date(yyyy_mm_dd){
+  if(yyyy_mm_dd.indexOf('-') == -1){ return yyyy_mm_dd; }
+  else{
+    let tokens = yyyy_mm_dd.split('-')
+    let year = tokens[0];
+    let month = parseInt(tokens[1]);
+    let day = tokens[2];
+
+    return `${months[month-1]} ${day}, ${year}`;
+  }
+}
+
 
 /* enable setting of active tab via the a '?page=' search paramater */
 if(window.location.search.includes("page=")){

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ const temp_project_detail = (project) => html`
     <hr />
   </li>`;
   const temp_projects_detail = (projects) => 
-    html`<ul>${projects.map((project) => temp_project_detail(project))}</ul>`;
+    html`<ul class="no-bullet pll">${projects.map((project) => temp_project_detail(project))}</ul>`;
   async function renderProjectsDetail(projects){
     render(temp_projects_detail(projects.slice(0,8)), document.getElementById("projects-detail"));
   }
@@ -127,20 +127,20 @@ let presentations_url = url_base_data+"presentations.json";
 getDataFromJSONFileAndCallRenderFunction(presentations_url, renderTalks);
 const temp_talk = (talk) => html`
   <li>
-    <div style="display: flex; flex-wrap: wrapped;">
-      <iframe class="pal" width="450" src="${talk.slides_embed}" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+    <div class="flex">
+      <iframe class="pal" width="400" src="${talk.slides_embed}" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
       <div class="pll txtv">
         <h3 class="mbm">${talk.title} [<a target="_blank" href="https://docs.google.com/presentation/d/${talk.slides_id}/edit?usp=sharing">slides</a>]</h3>
         <em class="pbl">${talk.subtitle}</em>
         <p>${talk.description}</p>
         <div>
-          <strong><a href="${talk.conference_url}">${talk.conference_name}</a></strong> - 
+          <strong><a href="${talk.conference_url}" target="_blank">${talk.conference_name}</a></strong> - 
           <span>${humanize_date(talk.date)}</div>
         </div>
       </div>
     </div>
   </li><hr />`;
-const temp_talks = (talks) => html`<ul class="no-bullet"><hr />${talks.map((talk) => temp_talk(talk))}</ul>`;
+const temp_talks = (talks) => html`<ul class="no-bullet pll"><hr />${talks.map((talk) => temp_talk(talk))}</ul>`;
 async function renderTalks(presentations){
   render(temp_talks(presentations), document.getElementById("talks-list"));
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -17,23 +17,6 @@ footer a, footer a:visited,
 footer a:focus, header a:focus { font-weight: bold; }
 footer a:hover, header a:hover { color: white; }
 
-/* margin/padding utilities */ 
-.pam { padding: 10px; }
-.phm {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-.pls { padding-left: 5px; }
-.pll { padding-left: 15px; }
-.prl { padding-right: 15px; }
-.pbs { padding-bottom: 5px; }
-.pbl { padding-bottom: 15px; }
-.pts { padding-top: 5px; }
-.mla { margin-left: auto; }
-.mrs { margin-right: 5px; }
-.mtm { margin-top: 10px; }
-.mbm { margin-bottom: 10px; }
-
 /* text utilities */
 .txtc { text-align: center; }
 .txtv { margin-top: auto; margin-bottom: auto; }
@@ -61,9 +44,12 @@ a.btn {
 }
 a.btn:hover { color: black !important; background-color: whitesmoke; }
 .flex { display: flex; }
-.flex-wrap { flex-wrap: wrap; }
 
-@media only screen and (max-width: 450px){ 
+/* -- responsiveness -- */
+
+@media only screen and (max-width: 650px){
+  .flex { flex-wrap: wrap; }
+  .flex iframe { width: 100%; height: 250px; }
   .tabs > #resume-download { margin-right: auto; }
   header > * { margin-left: auto; margin-right: auto; text-align: center; }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,3 +1,10 @@
+/* -- css variable exceptions -- */
+body {
+  --color-button-background: white;
+  --color-button-background-dark: whitesmoke;
+  --color-button-text: black;
+}
+
 /* -- general utilities -- */
 body { width: 95%; }
 header { 
@@ -7,12 +14,12 @@ header {
 }
 header img { width: 75px; height: 75px; }
 footer, header { 
-  background-color: black;
-  color: whitesmoke; 
+  background-color: var(--color-primary-background, black);
+  color: var(--color-primary-text, whitesmoke); 
 }
 footer a, footer a:visited, 
   header a, header a:visited {
-  color: whitesmoke;
+  color: var(--color-primary-text, whitesmoke);
 }
 footer a:focus, header a:focus { font-weight: bold; }
 footer a:hover, header a:hover { color: white; }
@@ -34,16 +41,20 @@ ul.no-bullet { list-style: none; }
 
 /* -- layouts -- */
 a.btn { 
-  background-color: white; 
-  color: black !important; 
+  background-color: var(--color-button-background, white); 
+  color: var(--color-button-text, black) !important; 
   text-decoration: none;
-  margin-top: 5px; 
-  margin-bottom: 5px; 
-  padding: 5px; 
+  margin-top: var(--padding-small, 5px); 
+  margin-bottom: var(--padding-small, 5px); 
+  padding: var(--padding-small, 5px); 
   border-radius: 5px; 
-  border: 1px solid black;
+  border: 1px solid var(--color-button-text, black);
 }
-a.btn:hover { color: black !important; background-color: whitesmoke; }
+a.btn:hover { 
+  color: var(--color-button-text, black) !important; 
+  background-color: var(--color-button-background-dark, whitesmoke); 
+  text-decoration: underline;
+}
 .flex { display: flex; }
 
 /* -- responsiveness -- */

--- a/src/styles.css
+++ b/src/styles.css
@@ -38,7 +38,8 @@ a.btn {
   color: black !important; 
   text-decoration: none;
   margin-top: 5px; 
-  padding: 2px; 
+  margin-bottom: 5px; 
+  padding: 5px; 
   border-radius: 5px; 
   border: 1px solid black;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -24,6 +24,15 @@ footer a, footer a:visited,
 footer a:focus, header a:focus { font-weight: bold; }
 footer a:hover, header a:hover { color: white; }
 
+/* style no-javascript segments to stand out more */
+noscript > p {
+  padding-top: var(--padding-large, 10px);
+  padding-bottom: var(--padding-large, 10px);
+  border-top: 1px solid grey;
+  border-bottom: 1px solid grey;
+  font-style: italic;
+}
+
 /* text utilities */
 .txtc { text-align: center; }
 .txtv { margin-top: auto; margin-bottom: auto; }
@@ -32,7 +41,7 @@ footer a:hover, header a:hover { color: white; }
 .larger-text { font-size: x-large; }
 
 /* -- section styles -- */ 
-ul.no-bullet { list-style: none; }
+ul.no-bullet, ol.no-bullet { list-style: none; }
 #skills ul { display: table; }
 #skills ul li { display: table-row; }
 #skills ul li strong, #skills ul li span { 


### PR DESCRIPTION
### Description of Changes
- add new tab to `index.html` for presentations i've given at conferences
- add new section to `index.js` to fill in a `lit-html` template for each presentation it finds in `resume/data/presentations.json`
- start using `atla5/utils` css while we're at it (instead of `bulib/bulib-wc`)